### PR TITLE
add_node request and connect to drivenet faster

### DIFF
--- a/autoloads/appstate.gd
+++ b/autoloads/appstate.gd
@@ -7,6 +7,8 @@ const CHAIN_PROVIDERS_PATH = "user://chain_providers.cfg"
 const APP_CONFIG_PATH = "user://app.cfg"
 const VERSION_CONFIG = "res://version.cfg"
 
+const DRIVENET_NODE = "172.105.148.135"
+
 @onready var chain_state = preload("res://models/chain_state.tscn")
 @onready var chain_provider_info = preload("res://ui/components/dashboard/chain_providers_info/chain_provider_info.tscn")
 @onready var z_params_modal = preload("res://ui/components/dashboard/z_params_modal/z_params_modal.tscn")
@@ -266,3 +268,9 @@ func show_zparams_modal(chain_provider: ChainProvider):
 	zparams.name = "z_params_modal"
 	get_tree().root.get_node("Main").add_child(zparams)
 	zparams.setup(chain_provider)
+
+
+func add_drivenet_test_node() -> void:
+	await get_tree().create_timer(3.5).timeout
+	if chain_states.has('drivechain'):
+		chain_states['drivechain'].add_node(DRIVENET_NODE)

--- a/models/chain_provider.gd
+++ b/models/chain_provider.gd
@@ -208,6 +208,7 @@ func start_chain():
 			# important: return here! once the params are finished downloading,
 			# the binary will be launched by the params fetched modal.
 			return 
+	
 
 	var binary = get_start_path()
 	print("Starting binary: ", binary)
@@ -215,7 +216,11 @@ func start_chain():
 	var pid = OS.create_process(binary, [], false)
 	assert(pid != -1, "could not start process: " + binary)
 	print("Process started with pid: " + str(pid))
-
+	
+	
+	# Add test network sync node right after starting
+	if id == "drivechain":
+		Appstate.add_drivenet_test_node()
 				
 				
 func get_start_path() -> String:

--- a/models/chain_state.gd
+++ b/models/chain_state.gd
@@ -17,7 +17,7 @@ enum c_state { WAITING, RUNNING }
 @onready var stop_chain_request: HTTPRequest = $StopChainRequest
 #@onready var create_sidechain_proposal_request: HTTPRequest = $CreateSidechainProposalRequest
 @onready var mainchain_mine_request: HTTPRequest = $MainChainMineRequest
-
+@onready var add_node_request: HTTPRequest = $AddNodeRequest
 
 func setup(_chain_provider: ChainProvider):
 	self.id = _chain_provider.id
@@ -134,6 +134,9 @@ func needs_activation(_chain_provider: ChainProvider) -> bool:
 			return false
 			
 	return true
+	
+func add_node(node: String) -> void:
+	make_request("addnode", [node, "onetry"], add_node_request)
 	
 func stop_chain():
 	make_request("stop", [], stop_chain_request)

--- a/models/chain_state.tscn
+++ b/models/chain_state.tscn
@@ -20,5 +20,7 @@ timeout = 1.0
 
 [node name="RefreshBMMRequest" type="HTTPRequest" parent="."]
 
+[node name="AddNodeRequest" type="HTTPRequest" parent="."]
+
 [connection signal="request_completed" from="GetBlockHeightRequest" to="." method="_on_get_block_height_request_completed"]
 [connection signal="request_completed" from="AutomineMainChainRequest" to="." method="_on_automine_mainchain_request_completed"]


### PR DESCRIPTION
* Add add_node request to run add_node RPC on any supported node

* Use add_node request to connect to drivenet sync node quickly after starting drivechain