### PR TITLE
Add fast withdrawal dialog

### DIFF
--- a/net.gd
+++ b/net.gd
@@ -1,0 +1,52 @@
+extends Node
+
+# TODO rename this and move it on the server as well?
+
+# Server signals
+signal fast_withdraw_requested(peer : int, amount: float, destination: String)
+signal fast_withdraw_invoice_paid(peer : int, txid: String, amount: float, destination: String)
+
+# Client signals
+signal fast_withdraw_invoice(amount: float, destination: String)
+signal fast_withdraw_complete(txid: String, amount: float, destination: String)
+
+# TODO add params: SC #, MC fee, MC destination
+@rpc("any_peer", "call_remote", "reliable")
+func request_fast_withdraw(amount : float, destination : String) -> void:
+	print("Received fast withdrawal request")
+	print("Amount: ", amount)
+	print("Destination: ", destination)
+	print("Peer: ", multiplayer.get_remote_sender_id())
+	
+	fast_withdraw_requested.emit(multiplayer.get_remote_sender_id(), amount, destination)
+
+
+@rpc("authority", "call_remote", "reliable")
+func receive_fast_withdraw_invoice(amount : float, destination : String) -> void:
+	print("Received fast withdrawal invoice")
+	print("Amount: ", amount)
+	print("Destination: ", destination)
+	print("Peer: ", multiplayer.get_remote_sender_id())
+	
+	fast_withdraw_invoice.emit(amount, destination)
+
+
+@rpc("any_peer", "call_remote", "reliable")
+func invoice_paid(txid: String, amount : float, destination : String) -> void:
+	print("Paid fast withdrawal invoice")
+	print("Amount: ", amount)
+	print("Destination: ", destination)
+	print("Txid: ", txid)
+	print("Peer: ", multiplayer.get_remote_sender_id())
+	
+	fast_withdraw_invoice_paid.emit(multiplayer.get_remote_sender_id(), txid, amount, destination)
+
+
+@rpc("authority", "call_remote", "reliable")
+func withdraw_complete(txid: String, amount : float, destination : String) -> void:
+	print("Fast withdraw completed!")
+	print("Amount: ", amount)
+	print("Destination: ", destination)
+	print("Txid: ", txid)
+	
+	fast_withdraw_complete.emit(txid, amount, destination)

--- a/net.gd
+++ b/net.gd
@@ -1,5 +1,8 @@
 extends Node
 
+# Enable this for debug printing in net.gd and fast_withdraw.gd
+var print_debug_net : bool = false
+
 # TODO rename this and move it on the server as well?
 
 # Server signals
@@ -13,40 +16,44 @@ signal fast_withdraw_complete(txid: String, amount: float, destination: String)
 # TODO add params: SC #, MC fee, MC destination
 @rpc("any_peer", "call_remote", "reliable")
 func request_fast_withdraw(amount : float, destination : String) -> void:
-	print("Received fast withdrawal request")
-	print("Amount: ", amount)
-	print("Destination: ", destination)
-	print("Peer: ", multiplayer.get_remote_sender_id())
+	if print_debug_net:
+		print("Received fast withdrawal request")
+		print("Amount: ", amount)
+		print("Destination: ", destination)
+		print("Peer: ", multiplayer.get_remote_sender_id())
 	
 	fast_withdraw_requested.emit(multiplayer.get_remote_sender_id(), amount, destination)
 
 
 @rpc("authority", "call_remote", "reliable")
 func receive_fast_withdraw_invoice(amount : float, destination : String) -> void:
-	print("Received fast withdrawal invoice")
-	print("Amount: ", amount)
-	print("Destination: ", destination)
-	print("Peer: ", multiplayer.get_remote_sender_id())
+	if print_debug_net:
+		print("Received fast withdrawal invoice")
+		print("Amount: ", amount)
+		print("Destination: ", destination)
+		print("Peer: ", multiplayer.get_remote_sender_id())
 	
 	fast_withdraw_invoice.emit(amount, destination)
 
 
 @rpc("any_peer", "call_remote", "reliable")
 func invoice_paid(txid: String, amount : float, destination : String) -> void:
-	print("Paid fast withdrawal invoice")
-	print("Amount: ", amount)
-	print("Destination: ", destination)
-	print("Txid: ", txid)
-	print("Peer: ", multiplayer.get_remote_sender_id())
+	if print_debug_net:
+		print("Paid fast withdrawal invoice")
+		print("Amount: ", amount)
+		print("Destination: ", destination)
+		print("Txid: ", txid)
+		print("Peer: ", multiplayer.get_remote_sender_id())
 	
 	fast_withdraw_invoice_paid.emit(multiplayer.get_remote_sender_id(), txid, amount, destination)
 
 
 @rpc("authority", "call_remote", "reliable")
 func withdraw_complete(txid: String, amount : float, destination : String) -> void:
-	print("Fast withdraw completed!")
-	print("Amount: ", amount)
-	print("Destination: ", destination)
-	print("Txid: ", txid)
-	
+	if print_debug_net:
+		print("Fast withdraw completed!")
+		print("Amount: ", amount)
+		print("Destination: ", destination)
+		print("Txid: ", txid)
+		
 	fast_withdraw_complete.emit(txid, amount, destination)

--- a/project.godot
+++ b/project.godot
@@ -21,11 +21,13 @@ config/windows_native_icon="res://icon.ico"
 [autoload]
 
 Appstate="*res://autoloads/appstate.tscn"
+Net="*res://net.gd"
 
 [display]
 
 window/size/viewport_width=1024
 window/size/viewport_height=640
+window/subwindows/embed_subwindows=false
 
 [dotnet]
 

--- a/ui/components/fast_withdraw/fast_withdraw.gd
+++ b/ui/components/fast_withdraw/fast_withdraw.gd
@@ -1,0 +1,112 @@
+extends Control
+
+const SERVER_LOCALHOST = "127.0.0.1"
+const SERVER_L2L_GA = "172.105.148.135"
+
+const PORT = 8382
+
+var invoice_address : String = ""
+
+
+func _ready() -> void:
+	multiplayer.connected_to_server.connect(_on_connected_to_withdrawal_server)
+	multiplayer.connection_failed.connect(_on_failed_connect_to_withdrawal_server)
+	multiplayer.server_disconnected.connect(_on_disconnected_from_withdrawal_server)
+
+	$"/root/Net".fast_withdraw_invoice.connect(_on_fast_withdraw_invoice)
+	$"/root/Net".fast_withdraw_complete.connect(_on_fast_withdraw_complete)
+	
+
+func _on_connected_to_withdrawal_server() -> void:
+	print("CONNECTED")
+	
+	$LabelConnectionStatus.text = "Connected"
+	
+	$ButtonConnect.disabled = true
+	
+	
+func _on_disconnected_from_withdrawal_server() -> void:
+	print("DISCONNECTED")
+	
+	$LabelConnectionStatus.text = "Not Connected"
+	
+	$ButtonConnect.disabled = false
+	
+	
+func _on_failed_connect_to_withdrawal_server() -> void:
+	print("FAILED TO CONNECT")
+	
+	$LabelConnectionStatus.text = "Not Connected"
+	
+	$ButtonConnect.disabled = false
+
+
+func connect_to_withdrawal_server() -> void:
+	# Create fast withdraw client
+	var peer = ENetMultiplayerPeer.new()
+	if $CheckButtonLocalhost.is_pressed():
+		print("will connect to localhost")
+		
+		var error = peer.create_client(SERVER_LOCALHOST, PORT)
+		if error:
+			print("Error: ", error)
+	else:
+		print("will connect to ga")
+		var error = peer.create_client(SERVER_L2L_GA, PORT)
+		if error:
+			print("Error: ", error)
+	
+	$LabelConnectionStatus.text = "Connecting..."
+	
+	$ButtonConnect.disabled = true
+	
+	multiplayer.multiplayer_peer = peer
+
+
+func _on_fast_withdraw_invoice(amount : float, destination: String) -> void:
+	print("Received fast withdraw invoice!")
+	print("Amount: ", amount)
+	print("Destination: ", destination)
+	
+	var invoice_text = "Fast withdraw request received! Invoice created:\n"
+	invoice_text += str("Send ", amount, " L2 coins to ", destination, "\n") 
+	invoice_text += "Once you have paid enter the L2 txid and hit invoice paid"
+	
+	invoice_address = destination
+	
+	$LabelInvoice.text = invoice_text
+
+
+func _on_fast_withdraw_complete(txid: String, amount : float, destination: String) -> void:
+	print("Fast withdraw complete!")
+	print("TxID: ", txid)
+	print("Amount: ", amount)
+	print("Destination: ", destination)
+	
+	var output : String = "Withdraw complete!\n"
+	output += "Mainchain payout txid:\n" + txid + "\n"
+	output += "Amount: " + str(amount) + "\n"
+	output += "Destination: " + destination + "\n"
+	$LabelComplete.text = output
+	
+	if multiplayer.multiplayer_peer:
+		multiplayer.multiplayer_peer.close()
+
+
+func _on_button_copy_address_pressed() -> void:
+	DisplayServer.clipboard_set(invoice_address)
+	
+
+func _on_button_invoice_paid_pressed() -> void:
+	# Tell the server we paid
+	var txid : String = $LineEditTXID.text
+	$"/root/Net".invoice_paid.rpc_id(1, txid, $SpinBoxAmount.value, $LineEditMainchainAddress.text)
+
+
+func _on_button_request_invoice_pressed() -> void:
+	# Send fast withdraw request only to server
+	$"/root/Net".request_fast_withdraw.rpc_id(1, $SpinBoxAmount.value, $LineEditMainchainAddress.text)
+
+
+func _on_button_connect_pressed() -> void:
+	connect_to_withdrawal_server()

--- a/ui/components/fast_withdraw/fast_withdraw.gd
+++ b/ui/components/fast_withdraw/fast_withdraw.gd
@@ -18,7 +18,8 @@ func _ready() -> void:
 	
 
 func _on_connected_to_withdrawal_server() -> void:
-	print("CONNECTED")
+	if $"/root/Net".print_debug_net:
+		print("Connected to fast withdraw server")
 	
 	$LabelConnectionStatus.text = "Connected"
 	
@@ -26,7 +27,8 @@ func _on_connected_to_withdrawal_server() -> void:
 	
 	
 func _on_disconnected_from_withdrawal_server() -> void:
-	print("DISCONNECTED")
+	if $"/root/Net".print_debug_net:
+		print("Disonnected to fast withdraw server")
 	
 	$LabelConnectionStatus.text = "Not Connected"
 	
@@ -34,8 +36,9 @@ func _on_disconnected_from_withdrawal_server() -> void:
 	
 	
 func _on_failed_connect_to_withdrawal_server() -> void:
-	print("FAILED TO CONNECT")
-	
+	if $"/root/Net".print_debug_net:
+		print("Failed to connect to fast withdraw server")
+		
 	$LabelConnectionStatus.text = "Not Connected"
 	
 	$ButtonConnect.disabled = false
@@ -45,16 +48,18 @@ func connect_to_withdrawal_server() -> void:
 	# Create fast withdraw client
 	var peer = ENetMultiplayerPeer.new()
 	if $CheckButtonLocalhost.is_pressed():
-		print("will connect to localhost")
+		if $"/root/Net".print_debug_net:
+			print("Using fast withdraw server: localhost")
 		
 		var error = peer.create_client(SERVER_LOCALHOST, PORT)
-		if error:
-			print("Error: ", error)
+		if error and $"/root/Net".print_debug_net:
+			print_debug("Error: ", error)
 	else:
-		print("will connect to ga")
+		if $"/root/Net".print_debug_net:
+			print("Using fast withdraw server: L2L-GA")
 		var error = peer.create_client(SERVER_L2L_GA, PORT)
-		if error:
-			print("Error: ", error)
+		if error and $"/root/Net".print_debug_net:
+			print_debug("Error: ", error)
 	
 	$LabelConnectionStatus.text = "Connecting..."
 	
@@ -64,9 +69,10 @@ func connect_to_withdrawal_server() -> void:
 
 
 func _on_fast_withdraw_invoice(amount : float, destination: String) -> void:
-	print("Received fast withdraw invoice!")
-	print("Amount: ", amount)
-	print("Destination: ", destination)
+	if $"/root/Net".print_debug_net:
+		print("Received fast withdraw invoice!")
+		print("Amount: ", amount)
+		print("Destination: ", destination)
 	
 	var invoice_text = "Fast withdraw request received! Invoice created:\n"
 	invoice_text += str("Send ", amount, " L2 coins to ", destination, "\n") 
@@ -78,10 +84,11 @@ func _on_fast_withdraw_invoice(amount : float, destination: String) -> void:
 
 
 func _on_fast_withdraw_complete(txid: String, amount : float, destination: String) -> void:
-	print("Fast withdraw complete!")
-	print("TxID: ", txid)
-	print("Amount: ", amount)
-	print("Destination: ", destination)
+	if $"/root/Net".print_debug_net:
+		print("Fast withdraw complete!")
+		print("TxID: ", txid)
+		print("Amount: ", amount)
+		print("Destination: ", destination)
 	
 	var output : String = "Withdraw complete!\n"
 	output += "Mainchain payout txid:\n" + txid + "\n"

--- a/ui/components/fast_withdraw/fast_withdraw.tscn
+++ b/ui/components/fast_withdraw/fast_withdraw.tscn
@@ -1,0 +1,118 @@
+[gd_scene load_steps=2 format=3 uid="uid://b5wmjp1psgsvr"]
+
+[ext_resource type="Script" path="res://ui/components/fast_withdraw/fast_withdraw.gd" id="1_4itd0"]
+
+[node name="FastWithdraw" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_4itd0")
+
+[node name="ButtonRequestInvoice" type="Button" parent="."]
+layout_mode = 0
+offset_left = 15.0
+offset_top = 104.0
+offset_right = 303.0
+offset_bottom = 135.0
+text = "Request fast withdrawal test invoice"
+
+[node name="LineEditMainchainAddress" type="LineEdit" parent="."]
+layout_mode = 0
+offset_left = 14.0
+offset_top = 67.0
+offset_right = 429.0
+offset_bottom = 98.0
+placeholder_text = "Enter mainchain address"
+
+[node name="LabelInvoice" type="Label" parent="."]
+layout_mode = 0
+offset_left = 22.0
+offset_top = 147.0
+offset_right = 62.0
+offset_bottom = 170.0
+
+[node name="ButtonInvoicePaid" type="Button" parent="."]
+layout_mode = 0
+offset_left = 16.0
+offset_top = 278.0
+offset_right = 117.0
+offset_bottom = 309.0
+text = "Invoice Paid"
+
+[node name="LineEditTXID" type="LineEdit" parent="."]
+layout_mode = 0
+offset_left = 16.0
+offset_top = 239.0
+offset_right = 620.0
+offset_bottom = 270.0
+placeholder_text = "Enter L2 payment txid"
+
+[node name="LabelComplete" type="Label" parent="."]
+layout_mode = 0
+offset_left = 19.0
+offset_top = 321.0
+offset_right = 550.0
+offset_bottom = 344.0
+
+[node name="SpinBoxAmount" type="SpinBox" parent="."]
+layout_mode = 0
+offset_left = 620.0
+offset_top = 66.0
+offset_right = 776.0
+offset_bottom = 97.0
+min_value = 1.0
+value = 1.0
+suffix = "BTC"
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 0
+offset_left = 443.0
+offset_top = 71.0
+offset_right = 608.0
+offset_bottom = 94.0
+text = "Amount to withdraw:
+"
+
+[node name="ButtonCopyAddress" type="Button" parent="."]
+layout_mode = 0
+offset_left = 499.0
+offset_top = 176.0
+offset_right = 612.0
+offset_bottom = 207.0
+text = "Copy Address
+"
+
+[node name="CheckButtonLocalhost" type="CheckButton" parent="."]
+layout_mode = 0
+offset_left = 268.0
+offset_top = 24.0
+offset_right = 535.0
+offset_bottom = 55.0
+text = "Use localhost (debug) server"
+
+[node name="ButtonConnect" type="Button" parent="."]
+layout_mode = 0
+offset_left = 15.0
+offset_top = 21.0
+offset_right = 85.0
+offset_bottom = 52.0
+text = "connect
+"
+
+[node name="LabelConnectionStatus" type="Label" parent="."]
+layout_mode = 0
+offset_left = 100.0
+offset_top = 27.0
+offset_right = 216.0
+offset_bottom = 50.0
+text = "Not Connected"
+
+[connection signal="pressed" from="ButtonRequestInvoice" to="." method="_on_button_request_invoice_pressed"]
+[connection signal="pressed" from="ButtonRequestInvoice" to="." method="_on_button_test_pressed"]
+[connection signal="pressed" from="ButtonInvoicePaid" to="." method="_on_button_invoice_paid_pressed"]
+[connection signal="pressed" from="ButtonInvoicePaid" to="." method="_on_button_test_complete_pressed"]
+[connection signal="pressed" from="ButtonCopyAddress" to="." method="_on_button_copy_address_pressed"]
+[connection signal="pressed" from="ButtonConnect" to="." method="_on_button_connect_pressed"]

--- a/ui/components/fast_withdraw/fast_withdraw.tscn
+++ b/ui/components/fast_withdraw/fast_withdraw.tscn
@@ -110,8 +110,8 @@ offset_right = 216.0
 offset_bottom = 50.0
 text = "Not Connected"
 
-[connection signal="pressed" from="ButtonRequestInvoice" to="." method="_on_button_request_invoice_pressed"]
 [connection signal="pressed" from="ButtonRequestInvoice" to="." method="_on_button_test_pressed"]
+[connection signal="pressed" from="ButtonRequestInvoice" to="." method="_on_button_request_invoice_pressed"]
 [connection signal="pressed" from="ButtonInvoicePaid" to="." method="_on_button_invoice_paid_pressed"]
 [connection signal="pressed" from="ButtonInvoicePaid" to="." method="_on_button_test_complete_pressed"]
 [connection signal="pressed" from="ButtonCopyAddress" to="." method="_on_button_copy_address_pressed"]

--- a/ui/components/left_menu/left_menu.gd
+++ b/ui/components/left_menu/left_menu.gd
@@ -8,6 +8,10 @@ var          settings_shown    : int  = 0
 
 signal left_menu_button_pressed(v: int)
 
+func _ready() -> void:
+	$FastWithdrawWindow.hide()
+
+
 func _on_left_menu_button_toggled(button_pressed, v):
 	
 	settings_shown = 1-settings_shown
@@ -15,8 +19,15 @@ func _on_left_menu_button_toggled(button_pressed, v):
 	left_menu_button_pressed.emit(settings_shown)
 	
 
-
 func _on_close_button_pressed():
 	var shutter_tween : Tween = create_tween()
 	shutter_tween.parallel().tween_property( $MarginContainer, "scale", Vector2(1.0,0.0), 0.5 )
 	shutter_tween.parallel().tween_property( self, "size/y", 0.0, 0.5 )
+
+
+func _on_fast_withdraw_button_pressed() -> void:
+	$FastWithdrawWindow.show()
+
+
+func _on_fast_withdraw_window_close_requested() -> void:
+	$FastWithdrawWindow.hide()

--- a/ui/components/left_menu/left_menu.tscn
+++ b/ui/components/left_menu/left_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://dwhtby81ylt3s"]
+[gd_scene load_steps=12 format=3 uid="uid://dwhtby81ylt3s"]
 
 [ext_resource type="Theme" uid="uid://deiietf7bytje" path="res://ui/components/left_menu/left_menu_button.tres" id="1_vs06l"]
 [ext_resource type="Script" path="res://ui/components/left_menu/left_menu.gd" id="1_yja75"]
@@ -6,8 +6,10 @@
 [ext_resource type="Texture2D" uid="uid://blq6pvspmkcbj" path="res://assets/images/prev.svg" id="3_3lhq3"]
 [ext_resource type="Texture2D" uid="uid://djtv7qiy8hkat" path="res://assets/images/dashboard-3-line.svg" id="3_rgc2b"]
 [ext_resource type="Texture2D" uid="uid://srldhyvbmy57" path="res://assets/images/settings-4-line.svg" id="4_cr7m3"]
+[ext_resource type="Texture2D" uid="uid://drsftlr0wcb3m" path="res://assets/images/chain.svg" id="4_v0or6"]
 [ext_resource type="Texture2D" uid="uid://c5ddyq86urmmy" path="res://assets/images/next.svg" id="7_k0tsh"]
 [ext_resource type="Script" path="res://ui/components/left_menu/Quotes.gd" id="7_kx1k8"]
+[ext_resource type="PackedScene" uid="uid://b5wmjp1psgsvr" path="res://ui/components/fast_withdraw/fast_withdraw.tscn" id="10_kuvno"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_c8gs8"]
 bg_color = Color(0.141176, 0.141176, 0.141176, 1)
@@ -47,6 +49,11 @@ theme = ExtResource("1_vs06l")
 toggle_mode = true
 icon = ExtResource("4_cr7m3")
 alignment = 0
+
+[node name="FastWithdrawButton" type="Button" parent="MarginContainer/HBox"]
+layout_mode = 2
+text = "Fast Withdraw"
+icon = ExtResource("4_v0or6")
 
 [node name="DashboardButton" type="Button" parent="MarginContainer/HBox"]
 visible = false
@@ -113,9 +120,18 @@ size_flags_vertical = 4
 icon = ExtResource("2_ahqh1")
 flat = true
 
+[node name="FastWithdrawWindow" type="Window" parent="."]
+title = "Drivechain Launcher Fast Withdrawal"
+initial_position = 2
+size = Vector2i(800, 500)
+
+[node name="FastWithdraw" parent="FastWithdrawWindow" instance=ExtResource("10_kuvno")]
+
 [connection signal="toggled" from="MarginContainer/HBox/SettingsButton" to="." method="_on_left_menu_button_toggled" binds= [1]]
+[connection signal="pressed" from="MarginContainer/HBox/FastWithdrawButton" to="." method="_on_fast_withdraw_button_pressed"]
 [connection signal="toggled" from="MarginContainer/HBox/DashboardButton" to="." method="_on_left_menu_button_toggled" binds= [0]]
 [connection signal="pressed" from="MarginContainer/HBox/PrevButton" to="MarginContainer/HBox/Quotes" method="_on_prev_button_pressed"]
 [connection signal="toggled" from="MarginContainer/HBox/PlaygroundButton" to="." method="_on_left_menu_button_toggled" binds= [1]]
 [connection signal="pressed" from="MarginContainer/HBox/NextButton" to="MarginContainer/HBox/Quotes" method="_on_next_button_pressed"]
 [connection signal="pressed" from="MarginContainer/HBox/CloseButton" to="." method="_on_close_button_pressed"]
+[connection signal="close_requested" from="FastWithdrawWindow" to="." method="_on_fast_withdraw_window_close_requested"]


### PR DESCRIPTION
Add fast withdraw window to launcher

* Add fast withdraw network script, autoloaded

* Disabled embedding sub windows in project settings

* Add a fast withdraw button to the left_menu component

* Add fast withdrawal scene and script

* Show fast withdrawal window if button is pressed


@seriouscatsoserious feel free to move the button wherever you want and change the ugly scene. This only works for testchain right now. Tested with my own mainchain & testchain configuration but still needs to be tested with the way the launcher sets things up. 

The file `net.gd`  cannot be moved and has to exactly match this file from the server:
https://github.com/LayerTwo-Labs/fast-withdraw-server/blob/master/net.gd